### PR TITLE
Fix version conflicts caused by PR#157

### DIFF
--- a/Silkier.EFCore/Silkier.EFCore.csproj
+++ b/Silkier.EFCore/Silkier.EFCore.csproj
@@ -13,8 +13,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.8" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\docs\logo.png">


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump Microsoft.EntityFrameworkCore.Relational from 5.0.4 to 5.0.8. [(PR#157)](https://github.com/maikebing/Silkier/pull/157).
Hope this fix can help you.

Best regards,
sucrose